### PR TITLE
AY-65 integrate match enums in FE and BE, resolve roles vs provider types

### DIFF
--- a/api/orders/serializers.py
+++ b/api/orders/serializers.py
@@ -1,17 +1,24 @@
 from rest_framework import serializers
 from .models import Order, Profile
-from .utils.constants import PRICES, DESCRIPTIONS
+from utils.constants import (
+    PRICES,
+    DESCRIPTIONS,
+    ServiceType,
+    CleaningJobs,
+    MaintenanceJobs,
+)
 
 
 # MinimalProfileSerializer to avoid sending unnecessary provider data with orders
 class MinimalProfileSerializer(serializers.ModelSerializer):
     class Meta:
         model = Profile
-        fields = ["first_name", "last_name"]
+        fields = ["first_name", "last_name", "user_num"]
 
 
 class OrderSerializer(serializers.ModelSerializer):
     provider = MinimalProfileSerializer(read_only=True)
+    client = MinimalProfileSerializer(read_only=True)
     price = serializers.SerializerMethodField()
     description = serializers.SerializerMethodField()
 
@@ -21,16 +28,34 @@ class OrderSerializer(serializers.ModelSerializer):
     def get_description(self, obj):
         return DESCRIPTIONS.get(obj.job, "No description available.")
 
+    def validate(self, data):
+        service = data.get("service_type")
+        job = data.get("job")
+        if service and job:
+            if service == ServiceType.CLEANING:
+                valid_jobs = CleaningJobs.values
+            elif service == ServiceType.MAINTENANCE:
+                valid_jobs = MaintenanceJobs.values
+            else:
+                raise serializers.ValidationError("Invalid service type.")
+            if job not in valid_jobs:
+                raise serializers.ValidationError(
+                    f"'{job}' is not valid for service '{service}'"
+                )
+        return data
+
     class Meta:
         model = Order
         fields = [
             "order_num",
             "provider",
+            "client",
             "payment_token",
             "start_time",
             "end_time",
             "status",
             "service_type",
+            "job",
             "comments",
             "rating",
             "created_at",

--- a/api/orders/serializers.py
+++ b/api/orders/serializers.py
@@ -1,15 +1,30 @@
 from rest_framework import serializers
-from .models import Order
+from .models import Order, Profile
+from .utils.constants import PRICES, DESCRIPTIONS
 
 
-# Going to need to grab some data from the User model as well so will need to import it
-# Maybe could use a minimal serializer just to grab the first and last name of providers and nest it in the OrderSerializer
+# MinimalProfileSerializer to avoid sending unnecessary provider data with orders
+class MinimalProfileSerializer(serializers.ModelSerializer):
+    class Meta:
+        model = Profile
+        fields = ["first_name", "last_name"]
+
+
 class OrderSerializer(serializers.ModelSerializer):
+    provider = MinimalProfileSerializer(read_only=True)
+    price = serializers.SerializerMethodField()
+    description = serializers.SerializerMethodField()
+
+    def get_price(self, obj):
+        return PRICES.get(obj.job, 0.0)
+
+    def get_description(self, obj):
+        return DESCRIPTIONS.get(obj.job, "No description available.")
+
     class Meta:
         model = Order
         fields = [
             "order_num",
-            "client",
             "provider",
             "payment_token",
             "start_time",

--- a/api/orders/views.py
+++ b/api/orders/views.py
@@ -4,5 +4,17 @@ from .serializers import OrderSerializer
 
 
 class OrderViewSet(ModelViewSet):
-    queryset = Order.objects.all()
     serializer_class = OrderSerializer
+    # Uncomment to enable authentication
+    # permission_classes = [IsAuthenticated]
+
+    def get_queryset(self):
+        # Uncomment to enable authentication
+        # user = self.request.user
+        # if not user.is_authenticated:
+        #     return Order.objects.none()
+        #
+        # return Order.objects.filter(client=user.profile).select_related("provider")
+
+        # For testing purposes, before we add auth
+        return Order.objects.all()

--- a/api/users/models.py
+++ b/api/users/models.py
@@ -2,6 +2,7 @@ from django.db import models
 from random import choices
 from string import ascii_uppercase, digits
 from django.core.exceptions import ValidationError
+from utils.constants import Role, ServiceType
 
 
 def generate_user_num(length=6):
@@ -19,22 +20,13 @@ class SupaUser(models.Model):
 
 
 class Profile(models.Model):
-    ROLE_CHOICES = [
-        ("client", "Client"),
-        ("provider", "Provider"),
-    ]
-    PROVIDER_TYPE_CHOICES = [
-        ("cleaning", "Cleaning"),
-        ("maintenance", "Maintenance"),
-    ]
-
     id = models.AutoField(primary_key=True)
     user_num = models.CharField(max_length=6, unique=True)
     first_name = models.CharField(max_length=20)
     last_name = models.CharField(max_length=20)
-    role = models.CharField(max_length=20, choices=ROLE_CHOICES, default="client")
+    role = models.CharField(max_length=20, choices=Role.choices, default=Role.CLIENT)
     provider_type = models.CharField(
-        max_length=20, choices=PROVIDER_TYPE_CHOICES, blank=True, null=True
+        max_length=20, choices=ServiceType.choices, blank=True, null=True
     )
     street_address = models.CharField(max_length=50)
     city = models.CharField(max_length=50)

--- a/api/users/models.py
+++ b/api/users/models.py
@@ -36,13 +36,13 @@ class Profile(models.Model):
     # create api that uses email to connect supabaseid
 
     def __str__(self):
-        return str(self.first_name + " " + self.last_name)
+        return f"{self.first_name or ''} {self.last_name or ''}".strip()
 
     def clean(self):
         super().clean()
-        if self.role == "provider" and not self.provider_type:
+        if self.role == Role.PROVIDER and not self.provider_type:
             raise ValidationError("Provider type is required for providers.")
-        if self.role != "provider" and self.provider_type:
+        if self.role != Role.PROVIDER and self.provider_type:
             raise ValidationError("Only providers can have a provider type.")
 
     def save(self, *args, **kwargs):

--- a/api/users/serializers.py
+++ b/api/users/serializers.py
@@ -1,5 +1,6 @@
 from .models import Profile
 from rest_framework import serializers
+from utils.constants import Role
 
 
 class ProfileSerializer(serializers.ModelSerializer):
@@ -27,11 +28,11 @@ class ProfileSerializer(serializers.ModelSerializer):
             "provider_type", getattr(self.instance, "provider_type", None)
         )
 
-        if role == "provider" and not provider_type:
+        if role == Role.PROVIDER and not provider_type:
             raise serializers.ValidationError(
                 {"provider_type": "Provider type is required for providers."}
             )
-        if role != "provider" and provider_type:
+        if role != Role.PROVIDER and provider_type:
             raise serializers.ValidationError(
                 {"provider_type": "Only providers can have a provider type."}
             )

--- a/api/users/serializers.py
+++ b/api/users/serializers.py
@@ -12,6 +12,7 @@ class ProfileSerializer(serializers.ModelSerializer):
             "first_name",
             "last_name",
             "role",
+            "provider_type",
             "street_address",
             "city",
             "state",
@@ -19,3 +20,19 @@ class ProfileSerializer(serializers.ModelSerializer):
             "email",
         ]
         read_only_fields = ["user_num", "email"]
+
+    def validate(self, data):
+        role = data.get("role", getattr(self.instance, "role", None))
+        provider_type = data.get(
+            "provider_type", getattr(self.instance, "provider_type", None)
+        )
+
+        if role == "provider" and not provider_type:
+            raise serializers.ValidationError(
+                {"provider_type": "Provider type is required for providers."}
+            )
+        if role != "provider" and provider_type:
+            raise serializers.ValidationError(
+                {"provider_type": "Only providers can have a provider type."}
+            )
+        return data

--- a/api/users/views.py
+++ b/api/users/views.py
@@ -1,16 +1,21 @@
 from rest_framework.viewsets import ModelViewSet
 from .models import Profile
 from .serializers import ProfileSerializer
-from rest_framework.permissions import IsAuthenticated
+# from rest_framework.permissions import IsAuthenticated
 
 
 class ProfileViewSet(ModelViewSet):
     serializer_class = ProfileSerializer
-    permission_classes = [IsAuthenticated]
+    # Uncomment to enable authentication
+    # permission_classes = [IsAuthenticated]
 
     def get_queryset(self):
-        user = self.request.user
-        if not user.is_authenticated:
-            return Profile.objects.none()
+        # Uncomment to enable authentication
+        # user = self.request.user
+        # if not user.is_authenticated:
+        #     return Profile.objects.none()
 
-        return Profile.objects.filter(supabase_id=user.id)
+        # return Profile.objects.filter(supabase_id=user.id)
+
+        # For testing purposes, before we add auth
+        return Profile.objects.all()

--- a/api/utils/constants.py
+++ b/api/utils/constants.py
@@ -1,0 +1,95 @@
+from datetime import timedelta
+from django.db import models
+
+
+class ServiceType(models.TextChoices):
+    CLEANING = "cleaning", "Cleaning"
+    MAINTENANCE = "maintenance", "Maintenance"
+
+
+class StatusChoices(models.TextChoices):
+    SCHEDULED = "scheduled", "Scheduled"
+    ON_THE_WAY = "on-the-way", "On the way"
+    IN_PROGRESS = "in-progress", "In progress"
+    COMPLETED = "completed", "Completed"
+
+
+class CleaningJobs(models.TextChoices):
+    SINGLE_ROOM = "single_room", "Single Room"
+    APARTMENT = "apartment", "Apartment"
+    HOUSE = "house", "House"
+
+
+class MaintenanceJobs(models.TextChoices):
+    FIX_DOOR = "fix_door", "Fix Door"
+    FIX_SINK = "fix_sink", "Fix Sink"
+    INSTALL_SHELF = "install_shelf", "Install Shelf"
+    MOUNT_TV = "mount_tv", "Mount TV"
+    PAINTING = "painting", "Painting"
+    YARD_WORK = "yard_work", "Yard Work"
+    FURNITURE_ASSEMBLY = "furniture_assembly", "Furniture Assembly"
+    DRYWALL_REPAIR = "drywall_repair", "Drywall Repair"
+    LIGHT_FIXTURE_INSTALLATION = (
+        "light_fixture_installation",
+        "Light Fixture Installation",
+    )
+    APPLIANCE_INSTALLATION = "appliance_installation", "Appliance Installation"
+    FAUCET_REPLACEMENT = "faucet_replacement", "Faucet Replacement"
+    TOILET_REPAIR = "toilet_repair", "Toilet Repair"
+
+
+# For durations, prices, and descriptions, you can keep dicts keyed by the enum values
+
+DURATIONS = {
+    CleaningJobs.SINGLE_ROOM: timedelta(hours=1),
+    CleaningJobs.APARTMENT: timedelta(hours=3),
+    CleaningJobs.HOUSE: timedelta(hours=5),
+    MaintenanceJobs.FIX_DOOR: timedelta(hours=1),
+    MaintenanceJobs.FIX_SINK: timedelta(hours=1),
+    MaintenanceJobs.INSTALL_SHELF: timedelta(minutes=45),
+    MaintenanceJobs.MOUNT_TV: timedelta(minutes=45),
+    MaintenanceJobs.PAINTING: timedelta(hours=4),
+    MaintenanceJobs.YARD_WORK: timedelta(hours=2),
+    MaintenanceJobs.FURNITURE_ASSEMBLY: timedelta(hours=2),
+    MaintenanceJobs.DRYWALL_REPAIR: timedelta(hours=3),
+    MaintenanceJobs.LIGHT_FIXTURE_INSTALLATION: timedelta(hours=1, minutes=30),
+    MaintenanceJobs.APPLIANCE_INSTALLATION: timedelta(hours=2),
+    MaintenanceJobs.FAUCET_REPLACEMENT: timedelta(hours=1),
+    MaintenanceJobs.TOILET_REPAIR: timedelta(hours=1, minutes=15),
+}
+
+PRICES = {
+    CleaningJobs.SINGLE_ROOM: 50.0,
+    CleaningJobs.APARTMENT: 80.0,
+    CleaningJobs.HOUSE: 120.0,
+    MaintenanceJobs.FIX_DOOR: 45.0,
+    MaintenanceJobs.FIX_SINK: 60.0,
+    MaintenanceJobs.INSTALL_SHELF: 55.0,
+    MaintenanceJobs.MOUNT_TV: 70.0,
+    MaintenanceJobs.PAINTING: 150.0,
+    MaintenanceJobs.YARD_WORK: 75.0,
+    MaintenanceJobs.FURNITURE_ASSEMBLY: 90.0,
+    MaintenanceJobs.DRYWALL_REPAIR: 110.0,
+    MaintenanceJobs.LIGHT_FIXTURE_INSTALLATION: 65.0,
+    MaintenanceJobs.APPLIANCE_INSTALLATION: 100.0,
+    MaintenanceJobs.FAUCET_REPLACEMENT: 70.0,
+    MaintenanceJobs.TOILET_REPAIR: 80.0,
+}
+
+DESCRIPTIONS = {
+    CleaningJobs.SINGLE_ROOM: "A thorough cleaning of a single room including dusting, vacuuming, and surface wiping. Ideal for quick refreshes or small spaces.",
+    CleaningJobs.APARTMENT: "Comprehensive cleaning for an entire apartment, covering all rooms and common areas. Includes kitchen, bathroom, floors, and dusting.",
+    CleaningJobs.HOUSE: "Deep cleaning for a full house, addressing every room and surface in detail. Perfect for seasonal cleaning or move-in/move-out preparation.",
+    MaintenanceJobs.FIX_DOOR: "Repair and adjust doors to ensure proper alignment and smooth operation. Includes fixing hinges, handles, and locks as needed.",
+    MaintenanceJobs.FIX_SINK: "Troubleshoot and repair sink issues such as leaks, clogs, and faucet malfunctions. Ensures proper water flow and drainage.",
+    MaintenanceJobs.INSTALL_SHELF: "Mount shelves securely on walls or other surfaces to provide additional storage space. Includes measuring, drilling, and anchoring.",
+    MaintenanceJobs.MOUNT_TV: "Safely install wall mounts and secure televisions in desired locations. Includes cable management and alignment.",
+    MaintenanceJobs.PAINTING: "Apply paint or touch-ups to walls, ceilings, and other surfaces. Prepares surfaces and ensures even, clean finishes.",
+    MaintenanceJobs.YARD_WORK: "Perform outdoor tasks such as lawn mowing, trimming, weeding, and general yard cleanup. Keeps outdoor areas neat and healthy.",
+    MaintenanceJobs.FURNITURE_ASSEMBLY: "Assemble flat-pack or disassembled furniture following manufacturer instructions. Ensures sturdy and correct construction.",
+    MaintenanceJobs.DRYWALL_REPAIR: "Fix holes, cracks, and damages in drywall surfaces. Includes sanding, patching, and prepping for repainting.",
+    MaintenanceJobs.LIGHT_FIXTURE_INSTALLATION: "Install or replace lighting fixtures including ceiling lights, wall sconces, and outdoor lamps. Ensures safe electrical connections.",
+    MaintenanceJobs.APPLIANCE_INSTALLATION: "Set up and connect household appliances like dishwashers, ovens, and washing machines. Includes plumbing and electrical hookups.",
+    MaintenanceJobs.FAUCET_REPLACEMENT: "Remove old faucets and install new models to improve function and aesthetics. Ensures leak-free and secure fittings.",
+    MaintenanceJobs.TOILET_REPAIR: "Diagnose and fix toilet issues such as leaks, clogs, and flushing problems. Restores proper function and conserves water.",
+}

--- a/api/utils/constants.py
+++ b/api/utils/constants.py
@@ -2,6 +2,11 @@ from datetime import timedelta
 from django.db import models
 
 
+class Role(models.TextChoices):
+    CLIENT = "client", "Client"
+    PROVIDER = "provider", "Provider"
+
+
 class ServiceType(models.TextChoices):
     CLEANING = "cleaning", "Cleaning"
     MAINTENANCE = "maintenance", "Maintenance"

--- a/web/src/types/order.ts
+++ b/web/src/types/order.ts
@@ -11,9 +11,7 @@ export interface ApiProvider {
 }
 
 export interface Order {
-  id: number;
   provider: Provider | null;
-  client: number;
   orderNum: string;
   paymentToken: string | null;
   startTime: string;
@@ -26,7 +24,6 @@ export interface Order {
 }
 
 export interface OrderView {
-  id: number;
   providerName: string;
   serviceDate: string;
   serviceTime: string;
@@ -37,9 +34,7 @@ export interface OrderView {
 }
 
 export interface ApiOrder {
-  id: number;
   provider: ApiProvider | null;
-  client: number;
   order_num: string;
   payment_token: string | null;
   start_time: string;

--- a/web/src/types/user.ts
+++ b/web/src/types/user.ts
@@ -1,8 +1,8 @@
 import type { Role, State } from "./enums";
 
 export interface User {
-  id: number;
   email: string;
+  userNum: string;
   firstName: string;
   lastName: string;
   role: Role;
@@ -13,15 +13,13 @@ export interface User {
 }
 
 export interface ApiUser {
-  id: number;
   email: string;
-  user_metadata: {
-    first_name: string;
-    last_name: string;
-    role: Role;
-    state: State;
-    street_address: string;
-    city: string;
-    zip_code: string;
-  };
+  user_num: string;
+  first_name: string;
+  last_name: string;
+  role: Role;
+  state: State;
+  street_address: string;
+  city: string;
+  zip_code: string;
 }

--- a/web/src/utils/mappers.ts
+++ b/web/src/utils/mappers.ts
@@ -4,7 +4,6 @@ import type { User, ApiUser } from "@/types/user";
 // maps orders from API format to app format
 export function mapOrderRequest(apiOrder: ApiOrder): Order {
   return {
-    id: apiOrder.id,
     provider: apiOrder.provider
       ? {
           firstName: apiOrder.provider.first_name,
@@ -27,15 +26,15 @@ export function mapOrderRequest(apiOrder: ApiOrder): Order {
 // maps users from API format to app format
 export function mapUserRequest(apiUser: ApiUser): User {
   return {
-    id: apiUser.id,
     email: apiUser.email,
-    firstName: apiUser.user_metadata.first_name,
-    lastName: apiUser.user_metadata.last_name,
-    role: apiUser.user_metadata.role,
-    state: apiUser.user_metadata.state,
-    streetAddress: apiUser.user_metadata.street_address,
-    city: apiUser.user_metadata.city,
-    zipCode: apiUser.user_metadata.zip_code,
+    userNum: apiUser.user_num,
+    firstName: apiUser.first_name,
+    lastName: apiUser.last_name,
+    role: apiUser.role,
+    state: apiUser.state,
+    streetAddress: apiUser.street_address,
+    city: apiUser.city,
+    zipCode: apiUser.zip_code,
   };
 }
 
@@ -44,7 +43,6 @@ export function mapOrderToView(order: Order): OrderView {
   const startDate = new Date(order.startTime);
   const orderDate = new Date(order.createdAt);
   return {
-    id: order.id,
     providerName: order.provider
       ? `${order.provider.firstName} ${order.provider.lastName}`
       : "Your provider",

--- a/web/src/utils/supabaseClient.ts
+++ b/web/src/utils/supabaseClient.ts
@@ -6,12 +6,9 @@ import type { ApiOrder } from "@/types/order";
 
 // Mock user object returned from auth.getUser()
 const mockClient = {
-  id: 123,
   email: "testuser@example.com",
-  user_metadata: {
-    first_name: "Matthew",
-    last_name: "Sanner",
-  },
+  first_name: "Matthew",
+  last_name: "Sanner",
 };
 
 // Example service providers
@@ -28,9 +25,7 @@ const mockProvider2 = {
 // Seed data
 const mockApiOrders: ApiOrder[] = [
   {
-    id: 1,
     provider: mockProvider,
-    client: 123,
     order_num: "ORD001",
     payment_token: null,
     start_time: "2025-07-20T14:00:00Z",
@@ -42,9 +37,7 @@ const mockApiOrders: ApiOrder[] = [
     created_at: "2025-07-20T13:00:00Z",
   },
   {
-    id: 2,
     provider: mockProvider2,
-    client: 123,
     order_num: "ORD002",
     payment_token: null,
     start_time: "2025-07-22T16:00:00Z",
@@ -56,9 +49,7 @@ const mockApiOrders: ApiOrder[] = [
     created_at: "2025-07-22T15:00:00Z",
   },
   {
-    id: 3,
     provider: mockProvider,
-    client: 123,
     order_num: "ORD003",
     payment_token: null,
     start_time: "2025-07-24T10:00:00Z",
@@ -70,9 +61,7 @@ const mockApiOrders: ApiOrder[] = [
     created_at: "2025-07-24T09:00:00Z",
   },
   {
-    id: 4,
     provider: mockProvider2,
-    client: 123,
     order_num: "ORD004",
     payment_token: null,
     start_time: "2025-07-26T12:00:00Z",
@@ -84,9 +73,7 @@ const mockApiOrders: ApiOrder[] = [
     created_at: "2025-07-26T11:00:00Z",
   },
   {
-    id: 5,
     provider: mockProvider,
-    client: 123,
     order_num: "ORD005",
     payment_token: null,
     start_time: "2025-07-31T17:30:00Z",
@@ -98,9 +85,7 @@ const mockApiOrders: ApiOrder[] = [
     created_at: "2025-07-31T17:00:00Z",
   },
   {
-    id: 6,
     provider: mockProvider,
-    client: 123,
     order_num: "ORD006",
     payment_token: null,
     start_time: "2025-08-01T14:00:00Z",
@@ -112,9 +97,7 @@ const mockApiOrders: ApiOrder[] = [
     created_at: "2025-08-01T13:00:00Z",
   },
   {
-    id: 7,
     provider: mockProvider2,
-    client: 123,
     order_num: "ORD007",
     payment_token: null,
     start_time: "2025-08-03T09:00:00Z",
@@ -126,9 +109,7 @@ const mockApiOrders: ApiOrder[] = [
     created_at: "2025-08-02T15:00:00Z",
   },
   {
-    id: 8,
     provider: mockProvider,
-    client: 123,
     order_num: "ORD008",
     payment_token: null,
     start_time: "2025-08-05T12:00:00Z",


### PR DESCRIPTION
Combines our model enums with the enums Gerar had made in the pricing dictionary, resolves the issue of roles vs provider types by having roles be provider or client and then enforcing that providers must have a provider type and clients must not have a provider type. Removes ids from backend and frontend schemas since we will not be wanting to surface those at all. Adds a MinimalProfileSerializer to the orders serializers to expose names and user_num for the client and provider associated with an order, but not the rest of their info.