### PR TITLE
AY-80 makes orders work on customer portal, cleans up backend fields

### DIFF
--- a/api/orders/serializers.py
+++ b/api/orders/serializers.py
@@ -14,14 +14,15 @@ from utils.constants import (
 class MinimalProfileSerializer(serializers.ModelSerializer):
     class Meta:
         model = Profile
-        fields = ["first_name", "last_name", "user_num"]
+        fields = ["first_name", "last_name"]
 
 
 class OrderSerializer(serializers.ModelSerializer):
     provider = MinimalProfileSerializer(read_only=True)
-    client = MinimalProfileSerializer(read_only=True)
     price = serializers.SerializerMethodField()
     description = serializers.SerializerMethodField()
+    status = serializers.SerializerMethodField()
+    service_type = serializers.SerializerMethodField()
 
     @extend_schema_field(serializers.FloatField)
     def get_price(self, obj):
@@ -30,6 +31,21 @@ class OrderSerializer(serializers.ModelSerializer):
     @extend_schema_field(serializers.CharField)
     def get_description(self, obj):
         return DESCRIPTIONS.get(obj.job, "No description available.")
+
+    @extend_schema_field(serializers.CharField)
+    def get_status(self, obj):
+        status_mapping = {
+            "scheduled": "Scheduled",
+            "on-the-way": "On the way",
+            "in-progress": "In progress",
+            "completed": "Completed",
+        }
+        return status_mapping.get(obj.status, obj.status)
+
+    @extend_schema_field(serializers.CharField)
+    def get_service_type(self, obj):
+        service_mapping = {"cleaning": "Cleaning", "maintenance": "Maintenance"}
+        return service_mapping.get(obj.service_type, obj.service_type)
 
     def validate(self, data):
         service = data.get("service_type")
@@ -52,7 +68,6 @@ class OrderSerializer(serializers.ModelSerializer):
         fields = [
             "order_num",
             "provider",
-            "client",
             "payment_token",
             "start_time",
             "end_time",
@@ -65,4 +80,13 @@ class OrderSerializer(serializers.ModelSerializer):
             "price",
             "description",
         ]
-        read_only_fields = ["order_num", "start_time", "end_time", "created_at", "price", "description"]
+        read_only_fields = [
+            "order_num",
+            "start_time",
+            "end_time",
+            "created_at",
+            "price",
+            "description",
+            "status",
+            "service_type",
+        ]

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,7 +1,7 @@
 services:
   api:
     build:
-      context: ./api 
+      context: ./api
       dockerfile: Dockerfile
     command: >
       sh -c ". /app/.venv/bin/activate &&

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -18,7 +18,6 @@ import LandingPage from "./pages/LandingPage";
 import NavbarPages from "./components/NavbarPages";
 import NavbarAuth from "./components/NavbarAuth";
 
-
 function App() {
   const links: Link[] = [
     { url: "/home", label: "Home" },
@@ -28,39 +27,48 @@ function App() {
     <AuthProvider>
       <BrowserRouter>
         {/* Header */}
-        <div className="fixed top-0 inset-x-0 z-50 flex bg-white/90 backdrop-blur-md shadow-sm">
+        <div className="sticky top-0 inset-x-0 z-50 flex bg-white/90 backdrop-blur-md shadow-sm">
           <div className="flex w-2/12 h-full justify-end items-center gap-2 px-4 py-2 ">
-            <img src="/images/icon_no_text.png" alt="icon" height={50} width={50}/>   
-            <span className="text-xl text-center font-bold text-gray-900">HandsOff</span>
+            <img
+              src="/images/icon_no_text.png"
+              alt="icon"
+              height={50}
+              width={50}
+            />
+            <span className="text-xl text-center font-bold text-gray-900">
+              HandsOff
+            </span>
           </div>
 
           <div className="flex w-full h-full justify-center">
             <NavbarPages links={links} />
           </div>
           <div className="flex w-2/12 justify-center">
-            <NavbarAuth/>
+            <NavbarAuth />
           </div>
         </div>
         {/* Body */}
         <div className="w-full h-full ">
           <Routes>
-            <Route path="/" element={<HomePage/>} />
+            <Route path="/" element={<HomePage />} />
             <Route path="/services" element={<ServiceDetailsPage />} />
             <Route path="/sign-up" element={<SignUpPage />} />
             <Route path="/sign-in" element={<SignInPage />} />
             <Route path="/auth/callback" element={<AuthCallback />} />
-            <Route path="/customer-portal" element={
-              <ProtectedRoute>
-                <CustomerPortal />
-              </ProtectedRoute>
-            } />
+            <Route
+              path="/customer-portal"
+              element={
+                <ProtectedRoute>
+                  <CustomerPortal />
+                </ProtectedRoute>
+              }
+            />
             <Route path="/provider-portal" element={<ProviderPortal />} />
-            <Route path="/landing" element={<LandingPage/>}/>
+            <Route path="/landing" element={<LandingPage />} />
           </Routes>
         </div>
       </BrowserRouter>
     </AuthProvider>
-
   );
 }
 

--- a/web/src/types/order.ts
+++ b/web/src/types/order.ts
@@ -18,12 +18,16 @@ export interface Order {
   endTime: string;
   status: Status;
   serviceType: ServiceType;
+  job: string;
   comments: string;
   rating: number | null;
   createdAt: string;
+  price: number;
+  description: string;
 }
 
 export interface OrderView {
+  orderNum: string;
   providerName: string;
   serviceDate: string;
   serviceTime: string;
@@ -34,7 +38,7 @@ export interface OrderView {
 }
 
 export interface ProviderOrderView {
-  id: number;
+  orderNum: string;
   clientName: string;
   serviceDate: string;
   serviceLocation: string;
@@ -54,7 +58,10 @@ export interface ApiOrder {
   end_time: string;
   status: Status;
   service_type: ServiceType;
+  job: string;
   comments: string;
   rating: number | null;
   created_at: string;
+  price: number;
+  description: string;
 }

--- a/web/src/utils/mappers.ts
+++ b/web/src/utils/mappers.ts
@@ -10,16 +10,18 @@ export function mapOrderRequest(apiOrder: ApiOrder): Order {
           lastName: apiOrder.provider.last_name,
         }
       : null,
-    client: apiOrder.client,
     orderNum: apiOrder.order_num,
     paymentToken: apiOrder.payment_token,
     startTime: apiOrder.start_time,
     endTime: apiOrder.end_time,
     status: apiOrder.status,
     serviceType: apiOrder.service_type,
+    job: apiOrder.job,
     comments: apiOrder.comments,
     rating: apiOrder.rating,
     createdAt: apiOrder.created_at,
+    price: apiOrder.price,
+    description: apiOrder.description,
   };
 }
 
@@ -43,6 +45,7 @@ export function mapOrderToView(order: Order): OrderView {
   const startDate = new Date(order.startTime);
   const orderDate = new Date(order.createdAt);
   return {
+    orderNum: order.orderNum,
     providerName: order.provider
       ? `${order.provider.firstName} ${order.provider.lastName}`
       : "Your provider",


### PR DESCRIPTION
Makes the customer portal orders fetch properly through the Django endpoint, but only for the signed in user. Cleans up the fields across the backend models, serializers, views, and frontend type to make sure the appropriate data is being sent and is properly expected, including types. Also made a small change to the email logic in the order views.py just to align it such that it grabs the right url and key from supabase.